### PR TITLE
Initial TLS support

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -4,6 +4,9 @@ frigate:
   mqtt_auth: false
   mqtt_username: username
   mqtt_password: password
+  mqtt_port: 1883  # Optional, default: 1883
+  mqtt_use_tls: False  # Optional, default: False. Use TLS for broker connection
+  mqtt_tls_insecure: False  # Optional, default: False. Don't verify broker certificate
   main_topic: frigate
   camera:
     - birdcam

--- a/speciesid.py
+++ b/speciesid.py
@@ -23,6 +23,8 @@ config = None
 firstmessage = True
 
 DBPATH = './data/speciesid.db'
+DEFAULT_MQTT_PORT = 1833
+DEFAULT_INSECURE_TLS = False
 
 
 def classify(image):
@@ -236,7 +238,14 @@ def run_mqtt_client():
         password = config['frigate']['mqtt_password']
         client.username_pw_set(username, password)
 
-    client.connect(config['frigate']['mqtt_server'])
+    mqtt_port = config['frigate'].get('mqtt_port', DEFAULT_MQTT_PORT)
+    if config['frigate'].get('mqtt_use_tls', False):
+        ca_certs = config['frigate'].get('mqtt_tls_ca_certs')
+        client.tls_set(ca_certs)
+        client.tls_insecure_set(config['frigate'].get('mqtt_tls_insecure',
+                                                      DEFAULT_INSECURE_TLS))
+
+    client.connect(config['frigate']['mqtt_server'], mqtt_port)
     client.loop_forever()
 
 


### PR DESCRIPTION
Use TLS for broker connection.
The following configuration file parameters were added:
| Parameter | Required | Default Value | Notes |
| --- | --- | --- | --- |
| mqtt_port | False | 1883 | MQTT Broker connection port |
| mqtt_use_tls | False | False | Use TLS for broker connection |
| mqtt_insecure_tls | False | False | Don't verify broker certificate |
| mqtt_tls_ca_certs | False | None | Path to .pem file containing all trusted root certificates |